### PR TITLE
Fix authentication error and update database schema

### DIFF
--- a/controllers/UserController.js
+++ b/controllers/UserController.js
@@ -14,13 +14,11 @@ const Favorites = {
   COURSES: {
     model: CourseModel,
     collection: 'courses',
-    path: 'basic_info.code',
     set: 'favorite_subjects'
   },
   TEACHERS: {
     model: TeacherModel,
     collection: 'teachers',
-    path: 'teacher_id',
     set: 'favorite_teachers'
   }
 };
@@ -34,7 +32,7 @@ function addFavorite(req, res, favorite) {
   }
   req.body[favorite.collection].forEach(async item => {
     const query = {};
-    query[favorite.path] = item;
+    query['_id'] = item;
     promises.push(
       favorite.model
         .countDocuments(query)
@@ -57,8 +55,8 @@ function addFavorite(req, res, favorite) {
         .then(res.status(204).send())
         .catch();
     } else {
-      res.status(400).json(err => {
-        message: 'Invalid id';
+      res.status(400).json({
+        message: 'Invalid id'
       });
     }
   });
@@ -139,9 +137,9 @@ module.exports = {
         }
         bcrypt.compare(req.body.password, user.password, (err, success) => {
           if (err) {
-            return res.status(401).json({
-              message: 'Authentication failed'
-            });
+            // Error occurred when comparing passwords.
+            // Reject request with internal error.
+            return res.status(500).send();
           }
           if (success) {
             const token = jwt.sign(
@@ -174,6 +172,9 @@ module.exports = {
             tokenList[refreshToken] = response;
             return res.status(200).json(response);
           }
+          return res.status(401).json({
+            message: 'Authentication failed'
+          });
         });
       })
       .catch(err => {

--- a/server.js
+++ b/server.js
@@ -11,7 +11,8 @@ const authRoutes = require('./routes/auth');
 // Database
 mongoose
   .connect('mongodb://127.0.0.1:27017/grade_plus_plus', {
-    useNewUrlParser: true
+    useNewUrlParser: true,
+    useUnifiedTopology: true
   })
   .then(() => console.log('Connected to database...'))
   .catch(err => console.error(err));


### PR DESCRIPTION
The error thrown by bcrypt doesn't occur on password mismatch but due to an internal error.
This caused the API to not return an error response on incorrect password.
This PR fixes that, along with a schema change to some models' IDs.