### PR TITLE
Added version to predict

### DIFF
--- a/controllers/CourseController.js
+++ b/controllers/CourseController.js
@@ -8,8 +8,12 @@ module.exports = {
       if (error) {
         return res.status(400).send();
       }
-      if (response.version !== req.params.version_id) {
-        return this.predict(req, res);
+      const version = JSON.parse(response.body).toString();
+
+      if (version !== req.params.version_id) {
+        res.redirect(`/course/predict`);
+      } else {
+        return res.status(200).send();
       }
     });
   },


### PR DESCRIPTION
## Check version
In this PR, the `/course/check_version/:version_id` endpoint is fixed and now returns the new prediction when the version of the model and the version of the app are different. Otherwise, it responds with status code `200`.

## Predict
The endpoint `/course/predict` is updated to return the version of the model too.  The response looks like the following.
![image](https://user-images.githubusercontent.com/37141166/80274914-93e3c780-86e6-11ea-97c9-994fcf5bb22c.png)
